### PR TITLE
Support for WC Catalog Visibility Options

### DIFF
--- a/storefront-sticky-add-to-cart.php
+++ b/storefront-sticky-add-to-cart.php
@@ -295,12 +295,28 @@ final class Storefront_Sticky_Add_to_Cart {
 								echo '<span class="price">' . wp_kses_post( $product->get_price_html() ) . '</span> ' . wp_kses_post( $product->get_rating_html() );
 								echo wp_kses_post( apply_filters( 'woocommerce_stock_html', $availability_html, $availability['availability'], $product ) );
 
-								if ( $product->is_type( 'simple' ) ) {
-									echo '<br /><a href="' . esc_url( $product->add_to_cart_url() ) . '" class="button alt">' . esc_attr( $product->single_add_to_cart_text() ) . '</a>';
-								} else {
-									echo '<br /><a class="button alt variable">' . esc_attr__( 'Select options', 'storefront-sticky-add-to-cart' ) . '</a>';
-									wp_enqueue_script( 'ssatc-variable' );
-								}
+                                ob_start();
+
+                                if ( $product->is_type( 'simple' ) ) {
+    								echo '<br /><a href="' . esc_url( $product->add_to_cart_url() ) . '" class="button alt">' . esc_attr( $product->single_add_to_cart_text() ) . '</a>';
+    							} else {
+    								echo '<br /><a class="button alt variable">' . esc_attr__( 'Select options', 'storefront-sticky-add-to-cart' ) . '</a>';
+    								wp_enqueue_script( 'ssatc-variable' );
+    							}
+
+                                if ( class_exists ('WC_Catalog_Restrictions') ) {
+                                    if (!WC_Catalog_Restrictions_Filters::instance()->user_can_purchase( $product ))
+                                    {
+                                        ob_end_clean();
+                                        global $wc_cvo;
+                                        $html = apply_filters( 'catalog_visibility_alternate_add_to_cart_button', do_shortcode( wpautop( wptexturize( $wc_cvo->setting( 'wc_cvo_s_price_text' ) ) ) ) );
+
+                            			echo $html;
+                                    }
+                                }
+
+                                ob_end_flush();
+
 								echo '</div>';
 								?>
 							</div>


### PR DESCRIPTION
Add an output buffer around the add to cart button and conditionally clean the buffer, removing the button and replacing it with the alternate text defined in Catalog Visibility Options if `WC_Catalog_Restrictions` exists and `user_can_purchase( $product )` returns false.

I'm quite sure this could be improved, but it's a start.

#6 